### PR TITLE
Parse byte literals

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,23 +13,21 @@ Count from 10 to 1:
 ```assembly
 0x1fff:
     PUSHC
-    10
+    !10
     # print the number
     PRINTN
     # subtract one
     PUSHC
-    1
+    !1
     NEG
     ADD
     DUP
     # check if we are done
     JUMPZ
-    0x0D
-    0x20
+    !W0x200D
     # jump back to the print statement
     JUMP
-    0x01
-    0x20
+    !W0x2001
     # halt
     HCF
 ```
@@ -49,7 +47,7 @@ Parse an `.asm` file:
 let mut mem = StdMem::from_file("examples/programs/add.asm").unwrap();
 let mut cpu = Processor::new(ENTRYPOINT);
 
-cpu.execute_until_hcl(&mut mem)?;
+cpu.execute_until_hcf(&mut mem)?;
 ```
 
 An example is located at `examples/parse.rs`.
@@ -69,7 +67,7 @@ write_instructions!(mem : ENTRYPOINT =>
     HCF
 );
 
-cpu.execute_until_hcl(&mut mem)?;
+cpu.execute_until_hcf(&mut mem)?;
 ```
 
 An example is located at `examples/add.rs`.

--- a/examples/programs/add.asm
+++ b/examples/programs/add.asm
@@ -1,5 +1,7 @@
 0x1fff:
-	PUSHC 11
-	PUSHC 22
+	PUSHC
+	!11
+	PUSHC
+	!22
 	ADD
 	HCF

--- a/examples/programs/add_pr.asm
+++ b/examples/programs/add_pr.asm
@@ -1,8 +1,10 @@
 # This is an address label, all instruction after it will be located relative to it
 0x1:
 	# This is a `PUSHC` instruction with the necessary constant following it
-	PUSHC 0o7
-	PUSHC 0b11
+	PUSHC
+	!0o7
+	PUSHC
+	!0b11
 	ADD
 20:
 	HCF

--- a/examples/programs/readme.asm
+++ b/examples/programs/readme.asm
@@ -1,6 +1,4 @@
-%endianness(le)
-0xff1f:
-    %endianness(be)
+0x1fff:
     PUSHC
     !10
     # print the number
@@ -13,7 +11,7 @@
     DUP
     # check if we are done
     JUMPZ
-    !W0x200B
+    !W0x200D
     # jump back to the print statement
     JUMP
     !W0x2001

--- a/examples/programs/readme.asm
+++ b/examples/programs/readme.asm
@@ -1,6 +1,6 @@
-%endianess(be)
-
-0x1fff:
+%endianess(le)
+0xff1f:
+    %endianess(be)
     PUSHC
     !10
     # print the number

--- a/examples/programs/readme.asm
+++ b/examples/programs/readme.asm
@@ -1,0 +1,21 @@
+%endianess(be)
+
+0x1fff:
+    PUSHC
+    !10
+    # print the number
+    PRINTN
+    # subtract one
+    PUSHC
+    !1
+    NEG
+    ADD
+    DUP
+    # check if we are done
+    JUMPZ
+    !W0x200B
+    # jump back to the print statement
+    JUMP
+    !W0x2001
+    # halt
+    HCF

--- a/examples/programs/readme.asm
+++ b/examples/programs/readme.asm
@@ -1,6 +1,6 @@
-%endianess(le)
+%endianness(le)
 0xff1f:
-    %endianess(be)
+    %endianness(be)
     PUSHC
     !10
     # print the number

--- a/examples/readme.rs
+++ b/examples/readme.rs
@@ -1,8 +1,7 @@
 use color_eyre::eyre::Result;
 
-use cpu::memory::{Byte, StdMem, Word};
+use cpu::memory::{StdMem, Word};
 use cpu::processor::Processor;
-use cpu::write_instructions;
 use simple_logger::SimpleLogger;
 
 /// The main entrypoit. First instruction should be placed here.

--- a/examples/readme.rs
+++ b/examples/readme.rs
@@ -1,0 +1,22 @@
+use color_eyre::eyre::Result;
+
+use cpu::memory::{Byte, StdMem, Word};
+use cpu::processor::Processor;
+use cpu::write_instructions;
+use simple_logger::SimpleLogger;
+
+/// The main entrypoit. First instruction should be placed here.
+const ENTRYPOINT: Word = 0x1FFF;
+
+fn main() -> Result<()> {
+    color_eyre::install()?; // rust error handling
+    SimpleLogger::new().init().unwrap(); // logging
+
+    let mut mem = StdMem::from_file("examples/programs/readme.asm").unwrap();
+    mem.dump();
+    let mut cpu = Processor::new(ENTRYPOINT);
+
+    cpu.execute_until_hcf(&mut mem)?;
+
+    Ok(())
+}

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -1,6 +1,6 @@
 use std::{path::Path, str::FromStr};
 
-use self::parse::{ParseError, Parser};
+use self::parse::{ParseError, Parser, Endianess};
 
 pub mod parse;
 
@@ -65,7 +65,7 @@ impl<const S: usize> FromStr for Memory<S> {
     type Err = Vec<ParseError>;
 
     fn from_str(value: &str) -> std::result::Result<Self, <Self as FromStr>::Err> {
-        let parser = Parser::new(value, Memory::default());
+        let parser = Parser::new(value, Memory::default(), Endianess::default());
 
         parser.parse()
     }

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -1,6 +1,6 @@
 use std::{path::Path, str::FromStr};
 
-use self::parse::{ParseError, Parser, Endianess};
+use self::parse::{ParseError, Parser, Endianness};
 
 pub mod parse;
 
@@ -73,7 +73,7 @@ impl<const S: usize> FromStr for Memory<S> {
     type Err = Vec<ParseError>;
 
     fn from_str(value: &str) -> std::result::Result<Self, <Self as FromStr>::Err> {
-        let parser = Parser::new(value, Memory::default(), Endianess::default());
+        let parser = Parser::new(value, Memory::default(), Endianness::default());
 
         parser.parse()
     }

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -59,6 +59,14 @@ impl<const S: usize> Memory<S> {
         (&mut self.data[position as usize..position as usize + data.len() as usize])
             .copy_from_slice(data);
     }
+
+    pub fn dump(&self) {
+        for (idx, byte) in self.data.iter().enumerate() {
+            if byte != &0 {
+                println!("0x{:04x}: 0x{:02x}", idx, byte);
+            }
+        }
+    }
 }
 
 impl<const S: usize> FromStr for Memory<S> {

--- a/src/memory/parse.rs
+++ b/src/memory/parse.rs
@@ -349,7 +349,7 @@ impl<'a, const S: usize> Parser<'a, S> {
 
         let instruction = *propagate!(Instruction::ALL
             .iter()
-            .find(|instruction| line.starts_with(instruction.name()))
+            .find(|instruction| line == instruction.name())
             .ok_or_else(|| ParseError::new(
                 ParseErrorKind::InvalidInstruction,
                 "no instruction matching that name was found",
@@ -421,7 +421,7 @@ impl<'a, const S: usize> Parser<'a, S> {
     ///
     /// - [`Parser::inc_memory_position`]
     fn write_be_word<B: Into<Word>>(&mut self, word: B) -> Result<()> {
-        self.memory.write_word(self.sp, word.into().rotate_left(8));
+        self.memory.write_word(self.sp, word.into());
         self.add_memory_position(2)
     }
 
@@ -437,7 +437,7 @@ impl<'a, const S: usize> Parser<'a, S> {
     ///
     /// - [`Parser::inc_memory_position`]
     fn write_le_word<B: Into<Word>>(&mut self, word: B) -> Result<()> {
-        self.memory.write_word(self.sp, word.into());
+        self.memory.write_word(self.sp, word.into().rotate_left(8));
         self.add_memory_position(2)
     }
 }

--- a/src/memory/parse.rs
+++ b/src/memory/parse.rs
@@ -10,7 +10,7 @@ use std::{fmt, str::Lines};
 
 use crate::processor::Instruction;
 
-use super::{Byte, Memory};
+use super::{Byte, Memory, Word};
 
 macro_rules! propagate {
     ( $res:expr ) => {
@@ -25,6 +25,8 @@ macro_rules! propagate {
 pub enum ParseErrorKind {
     InvalidAddress { address: usize },
     InvalidConstant,
+    InvalidLiteral,
+    InvalidMetaCommand,
     InvalidNumber { radix: u32 },
     InvalidInstruction,
     InvalidAddressLabel,
@@ -36,7 +38,9 @@ impl fmt::Display for ParseErrorKind {
             ParseErrorKind::InvalidAddress { address } => {
                 write!(f, "memory has no address `0x{:x}`", address)
             }
-            ParseErrorKind::InvalidConstant => f.write_str("failed to resolve constant"),
+            ParseErrorKind::InvalidConstant => f.write_str("invalid constant"),
+            ParseErrorKind::InvalidLiteral => f.write_str("invalid literal"),
+            ParseErrorKind::InvalidMetaCommand => f.write_str("invalid meta command"),
             ParseErrorKind::InvalidNumber { radix } => {
                 write!(f, "failed to parse number with radix `{}`", radix)
             }
@@ -85,21 +89,68 @@ impl error::Error for ParseError {}
 
 pub type Result<T, E = ParseError> = std::result::Result<T, E>;
 
+macro_rules! parse_number {
+    ( $ty:ty: $s:expr ) => {{
+        let line = $s;
+
+        if line.trim().is_empty() {
+            return None;
+        }
+
+        let (radix, offset) = match line.as_bytes() {
+            [b'0', b'b', ..] => (2, 2),
+            [b'0', b'o', ..] => (8, 2),
+            [b'0', b'x', ..] => (16, 2),
+            _ => (10, 0),
+        };
+
+        Some(<$ty>::from_str_radix(&line[offset..], radix).map_err(|_| radix))
+    }};
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Endianess {
+    Little,
+    Big,
+}
+
+impl Default for Endianess {
+    fn default() -> Self {
+        Self::Big
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ParseSession {
+    endianess: Endianess,
+}
+
+impl ParseSession {
+    fn new(endianess: Endianess) -> Self {
+        Self { endianess }
+    }
+}
+
+#[derive(Debug, Clone)]
 pub struct Parser<'a, const S: usize> {
     lines: Lines<'a>,
     line_nr: usize,
     sp: u16,
     memory: Memory<S>,
+    endianess: Endianess,
+    session: ParseSession,
 }
 
 impl<'a, const S: usize> Parser<'a, S> {
     /// Creates a new parse for `data` which will try to populate `memory`.
-    pub fn new(data: &'a str, memory: Memory<S>) -> Self {
+    pub fn new(data: &'a str, memory: Memory<S>, endianess: Endianess) -> Self {
         Self {
             lines: data.lines(),
             line_nr: 0,
             sp: 0,
             memory,
+            endianess,
+            session: ParseSession::new(endianess),
         }
     }
 
@@ -128,122 +179,234 @@ impl<'a, const S: usize> Parser<'a, S> {
     /// Tries to parse the next line of [`Parser::data`]. Each instruction
     /// should be located on it's own line.
     fn parse_next_line(&mut self) -> Option<Result<()>> {
-        macro_rules! parse_number {
-            ( $ty:ty: $s:expr ) => {{
-                let line = $s;
-
-                if line.trim().is_empty() {
-                    return None;
-                }
-
-                let (radix, offset) = match line.as_bytes() {
-                    [b'0', b'b', ..] => (2, 2),
-                    [b'0', b'o', ..] => (8, 2),
-                    [b'0', b'x', ..] => (16, 2),
-                    _ => (10, 0),
-                };
-
-                Some(<$ty>::from_str_radix(&line[offset..], radix).map_err(|_| radix))
-            }};
-        }
-
         let line = self.lines.next()?.trim();
         self.line_nr += 1;
 
         if line.is_empty() || line.starts_with('#') {
-            return Some(Ok(()));
+            // Comment or empty line; skip
+            Some(Ok(()))
+        } else if line.starts_with('%') {
+            // Line is a literal
+            self.parse_meta_command(line)
+        } else if line.starts_with('!') {
+            // Line is a literal
+            self.parse_literal(line)
+        } else if line.ends_with(':') {
+            // Line is a address label.
+            self.parse_address_label(line)
+        } else {
+            // Line is an instruction.
+            self.parse_instruction(line)
+        }
+    }
+
+    /// Tries to parse line a meta command. The `line` should be the whole line
+    /// whithout any modifications.
+    ///
+    /// # Examples
+    ///
+    /// - `%endianess(le)`
+    /// - `%endianess(be)`
+    fn parse_meta_command(&mut self, line: &str) -> Option<Result<()>> {
+        let line = line.strip_prefix('%').expect("Line is not a meta command");
+
+        log::debug!("[{}] Found meta command", self.line_nr);
+
+        match line {
+            "endianess" => {
+                self.session.endianess = self.endianess;
+            }
+            "endianess(le)" => {
+                self.session.endianess = Endianess::Little;
+            }
+            "endianess(be)" => {
+                self.session.endianess = Endianess::Big;
+            }
+            _ => {
+                return Some(Err(ParseError::new(
+                    ParseErrorKind::InvalidMetaCommand,
+                    format!("unknown command `{}`", line),
+                    self.line_nr,
+                )))
+            }
         }
 
-        if let Some(line) = line.strip_suffix(':') {
-            // Line is likely a address label.
+        Some(Ok(()))
+    }
 
-            log::debug!("[{}] Found address label", self.line_nr);
+    /// Tries to parse line as literal. The `line` should be the whole line
+    /// whithout any modifications.
+    ///
+    /// # Examples
+    ///
+    /// - `! 0x22`
+    /// - `!W0xdead`
+    fn parse_literal(&mut self, line: &str) -> Option<Result<()>> {
+        let line = line.strip_prefix('!').expect("Line is not a literal line");
 
-            // The address is intentionally parsed as an u16 to detect if it's
-            // a valid address.
-            let address =
+        if let Some(line) = line.strip_prefix('W') {
+            // Literal is a word
+            log::debug!("[{}] Found word literal", self.line_nr);
+
+            let line = line.trim();
+
+            let word =
                 propagate!(
                     propagate!(parse_number!(u16: line).ok_or_else(|| ParseError::new(
-                        ParseErrorKind::InvalidAddressLabel,
-                        "an address label needs to have an address set",
+                        ParseErrorKind::InvalidLiteral,
+                        "a literal needs to have a number set",
                         self.line_nr
                     )))
                     .map_err(|radix| {
                         ParseError::new(
-                            ParseErrorKind::InvalidAddress {
-                                address: usize::MAX,
-                            },
-                            format!("failed to parse the address with radix `{}`", radix),
+                            ParseErrorKind::InvalidLiteral,
+                            format!("failed to parse literal as word with radix `{}`", radix),
                             self.line_nr,
                         )
                     })
                 );
 
-            log::debug!("[{}] Address label `0x{:x}`", self.line_nr, address);
-
-            self.sp = address;
-        } else {
-            let instruction = *propagate!(Instruction::ALL
-                .iter()
-                .find(|instruction| line.starts_with(instruction.name()))
-                .ok_or_else(|| ParseError::new(
-                    ParseErrorKind::InvalidInstruction,
-                    "no instruction matching that name was found",
-                    self.line_nr
-                )));
-
-            log::debug!("[{}] Found instruction {}", self.line_nr, instruction);
-
-            propagate!(self.write_byte(instruction));
-
-            match instruction {
-                Instruction::PUSHC => {
-                    log::debug!("[{}] Trying to parse constant of `PUSHC`", self.line_nr);
-
-                    if let Some(line) = line[instruction.name().len()..].strip_prefix(' ') {
-                        let line = line.trim_start();
-
-                        let constant =
-                            propagate!(propagate!(parse_number!(u8: line).ok_or_else(|| {
-                                ParseError::new(
-                                    ParseErrorKind::InvalidInstruction,
-                                    "a `PUSHC` needs to have a constant set after it",
-                                    self.line_nr,
-                                )
-                            }))
-                            .map_err(|radix| {
-                                ParseError::new(
-                                    ParseErrorKind::InvalidConstant,
-                                    format!("failed to parse the constant with radix `{}`", radix),
-                                    self.line_nr,
-                                )
-                            }));
-
-                        log::debug!("[{}] PUSHC `0x{:x}`", self.line_nr, constant);
-
-                        propagate!(self.write_byte(constant));
-                    } else {
-                        // No space as separator found
-                        return Some(Err(ParseError::new(
-                            ParseErrorKind::InvalidInstruction,
-                            "no space found separating the instruction and the constant",
-                            self.line_nr,
-                        )));
-                    }
-                }
-                // These are all explicitly listed so that when a new
-                // instruction get's added an error will occurs here and force
-                // the implementer to check if a special case needs to be added
-                // here.
-                Instruction::NOP
-                | Instruction::HCF
-                | Instruction::PRINTN
-                | Instruction::DUP
-                | Instruction::ADD
-                | Instruction::NEG
-                | Instruction::JUMP
-                | Instruction::JUMPZ => { /* NOP */ }
+            match self.session.endianess {
+                Endianess::Little => Some(self.write_le_word(word)),
+                Endianess::Big => Some(self.write_be_word(word)),
             }
+        } else {
+            // Literal is a byte
+            log::debug!("[{}] Found byte literal", self.line_nr);
+
+            let line = line.trim();
+
+            let byte =
+                propagate!(
+                    propagate!(parse_number!(u8: line).ok_or_else(|| ParseError::new(
+                        ParseErrorKind::InvalidLiteral,
+                        "a literal needs to have a number set",
+                        self.line_nr
+                    )))
+                    .map_err(|radix| {
+                        ParseError::new(
+                            ParseErrorKind::InvalidLiteral,
+                            format!("failed to parse literal as byte with radix `{}`", radix),
+                            self.line_nr,
+                        )
+                    })
+                );
+
+            Some(self.write_byte(byte))
+        }
+    }
+
+    /// Tries to parse line as an address label. The `line` should be the whole line
+    /// whithout any modifications.
+    ///
+    /// # Examples
+    ///
+    /// - `0x22:`
+    /// - `0o44:`
+    fn parse_address_label(&mut self, line: &str) -> Option<Result<()>> {
+        let line = line
+            .strip_suffix(':')
+            .expect("Line is not an address label");
+
+        log::debug!("[{}] Found address label", self.line_nr);
+
+        // The address is intentionally parsed as an u16 to detect if it's
+        // a valid address.
+        let address =
+            propagate!(
+                propagate!(parse_number!(u16: line).ok_or_else(|| ParseError::new(
+                    ParseErrorKind::InvalidAddressLabel,
+                    "an address label needs to have an address set",
+                    self.line_nr
+                )))
+                .map_err(|radix| {
+                    ParseError::new(
+                        ParseErrorKind::InvalidAddress {
+                            address: usize::MAX,
+                        },
+                        format!("failed to parse the address with radix `{}`", radix),
+                        self.line_nr,
+                    )
+                })
+            );
+
+        log::debug!("[{}] Address label `0x{:x}`", self.line_nr, address);
+
+        self.sp = address;
+
+        Some(Ok(()))
+    }
+
+    /// Tries to parse line as a instruction. The `line` should be the whole line
+    /// whithout any modifications.
+    ///
+    /// # Examples
+    ///
+    /// - `PUSHC 0x22`
+    /// - `ADD`
+    fn parse_instruction(&mut self, line: &str) -> Option<Result<()>> {
+        let line = line.trim();
+
+        let instruction = *propagate!(Instruction::ALL
+            .iter()
+            .find(|instruction| line.starts_with(instruction.name()))
+            .ok_or_else(|| ParseError::new(
+                ParseErrorKind::InvalidInstruction,
+                "no instruction matching that name was found",
+                self.line_nr
+            )));
+
+        log::debug!("[{}] Found instruction {}", self.line_nr, instruction);
+
+        propagate!(self.write_byte(instruction));
+
+        match instruction {
+            Instruction::PUSHC => {
+                log::debug!("[{}] Trying to parse constant of `PUSHC`", self.line_nr);
+
+                if let Some(line) = line[instruction.name().len()..].strip_prefix(' ') {
+                    let line = line.trim_start();
+
+                    let constant =
+                        propagate!(propagate!(parse_number!(u8: line).ok_or_else(|| {
+                            ParseError::new(
+                                ParseErrorKind::InvalidInstruction,
+                                "a `PUSHC` needs to have a constant set after it",
+                                self.line_nr,
+                            )
+                        }))
+                        .map_err(|radix| {
+                            ParseError::new(
+                                ParseErrorKind::InvalidConstant,
+                                format!("failed to parse the constant with radix `{}`", radix),
+                                self.line_nr,
+                            )
+                        }));
+
+                    log::debug!("[{}] PUSHC `0x{:x}`", self.line_nr, constant);
+
+                    propagate!(self.write_byte(constant));
+                } else {
+                    // No space as separator found
+                    return Some(Err(ParseError::new(
+                        ParseErrorKind::InvalidInstruction,
+                        "no space found separating the instruction and the constant",
+                        self.line_nr,
+                    )));
+                }
+            }
+            // These are all explicitly listed so that when a new
+            // instruction get's added an error will occurs here and force
+            // the implementer to check if a special case needs to be added
+            // here.
+            Instruction::NOP
+            | Instruction::HCF
+            | Instruction::PRINTN
+            | Instruction::DUP
+            | Instruction::ADD
+            | Instruction::NEG
+            | Instruction::JUMP
+            | Instruction::JUMPZ => { /* NOP */ }
         }
 
         Some(Ok(()))
@@ -295,6 +458,38 @@ impl<'a, const S: usize> Parser<'a, S> {
     fn write_byte<B: Into<Byte>>(&mut self, byte: B) -> Result<()> {
         self.memory.write_byte(self.sp, byte.into());
         self.inc_memory_position()
+    }
+
+    /// Writes big endian `word` into memory at (self.sp)[`Parser::sp`]. Then
+    /// it increments the stack pointer by two.
+    ///
+    /// # Errors
+    ///
+    /// This will return an error if an overflow would have occurred while
+    /// incrementing [self.sp](`Parser::sp`).
+    ///
+    /// # Related
+    ///
+    /// - [`Parser::inc_memory_position`]
+    fn write_be_word<B: Into<Word>>(&mut self, word: B) -> Result<()> {
+        self.memory.write_word(self.sp, word.into().rotate_left(8));
+        self.add_memory_position(2)
+    }
+
+    /// Writes little endian `word` into memory at (self.sp)[`Parser::sp`]. Then
+    /// it increments the stack pointer by two.
+    ///
+    /// # Errors
+    ///
+    /// This will return an error if an overflow would have occurred while
+    /// incrementing [self.sp](`Parser::sp`).
+    ///
+    /// # Related
+    ///
+    /// - [`Parser::inc_memory_position`]
+    fn write_le_word<B: Into<Word>>(&mut self, word: B) -> Result<()> {
+        self.memory.write_word(self.sp, word.into());
+        self.add_memory_position(2)
     }
 }
 
@@ -406,6 +601,54 @@ mod tests {
                 PUSHC 2
                 ADD
                 HCF
+        "#;
+
+        let mem = StdMem::from_str(data).unwrap();
+
+        assert_eq!(mem.read_byte(ENTRYPOINT + 0), Instruction::PUSHC.into());
+        assert_eq!(mem.read_byte(ENTRYPOINT + 1), 1);
+        assert_eq!(mem.read_byte(ENTRYPOINT + 2), Instruction::PUSHC.into());
+        assert_eq!(mem.read_byte(ENTRYPOINT + 3), 2);
+        assert_eq!(mem.read_byte(ENTRYPOINT + 4), Instruction::ADD.into());
+        assert_eq!(mem.read_byte(ENTRYPOINT + 5), Instruction::HCF.into());
+
+        Ok(())
+    }
+
+    #[test]
+    fn parse_add_literals() -> Result<()> {
+        const ENTRYPOINT: u16 = 0xdead;
+        let data = r#"
+            0xdead:
+                !W 0x1001
+                !W 0x1002
+                !  0x20
+                !  0x01
+        "#;
+
+        let mem = StdMem::from_str(data).unwrap();
+
+        assert_eq!(mem.read_byte(ENTRYPOINT + 0), Instruction::PUSHC.into());
+        assert_eq!(mem.read_byte(ENTRYPOINT + 1), 1);
+        assert_eq!(mem.read_byte(ENTRYPOINT + 2), Instruction::PUSHC.into());
+        assert_eq!(mem.read_byte(ENTRYPOINT + 3), 2);
+        assert_eq!(mem.read_byte(ENTRYPOINT + 4), Instruction::ADD.into());
+        assert_eq!(mem.read_byte(ENTRYPOINT + 5), Instruction::HCF.into());
+
+        Ok(())
+    }
+
+    #[test]
+    fn parse_add_meta_commands() -> Result<()> {
+        const ENTRYPOINT: u16 = 0xdead;
+        let data = r#"
+            0xdead:
+                %endianess(be)
+                !W 0x1001
+                %endianess(le)
+                !W 0x0210
+                !  0x20
+                !  0x01
         "#;
 
         let mem = StdMem::from_str(data).unwrap();

--- a/src/memory/parse.rs
+++ b/src/memory/parse.rs
@@ -578,9 +578,10 @@ mod tests {
     fn parse_add_literals() -> Result<()> {
         const ENTRYPOINT: u16 = 0xdead;
         let data = r#"
+            %endianess(be)
             0xdead:
-                !W 0x1001
-                !W 0x1002
+                !W 0x0110
+                !W 0x0210
                 !  0x20
                 !  0x01
         "#;
@@ -603,9 +604,9 @@ mod tests {
         let data = r#"
             0xdead:
                 %endianess(be)
-                !W 0x1001
+                !W 0x0110
                 %endianess(le)
-                !W 0x0210
+                !W 0x1002
                 !  0x20
                 !  0x01
         "#;

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -106,7 +106,7 @@ impl Processor {
             Instruction::NOP => {
                 self.pc += 1;
 
-                debug!("NOP");
+                //debug!("NOP");
             }
             Instruction::HCF => {
                 self.t = true; // set termination flag
@@ -166,7 +166,7 @@ impl Processor {
                 let addr = memory.read_word(self.pc + 1);
                 self.pc = addr;
 
-                debug!("JUMP {}", addr);
+                debug!("JUMP 0x{:04x}", addr);
             }
             Instruction::JUMPZ => {
                 let addr = memory.read_word(self.pc + 1);
@@ -178,7 +178,7 @@ impl Processor {
                     self.pc = addr;
                 }
 
-                debug!("JUMPZ {}: {}", addr, value);
+                debug!("JUMPZ 0x{:04x}: 0x{:02x}", addr, value);
             }
         }
 


### PR DESCRIPTION
Parser now accepts literal as input.

```text
0x1fff:
    PUSHC
    # Adds byte literal into memory
    !0o20
    # Adds word literal into memory
    !W0x2010
```

Ability to define endianness of input (only relevant for address labels and word literals).
Default: Big Endian

```text
%endianness(le)
0xff1f:
%endianness(be)
0x1fff:
```